### PR TITLE
Fix/eip 681 array parsing + query parameters encoding

### DIFF
--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -109,7 +109,7 @@ extension Web3 {
                     if let ethAddress = EthereumAddress(string) {
                         return ethAddress.address
                     }
-                    if let url = URL(string: string) {
+                    if URL(string: string) != nil {
                         return string
                     }
                 }
@@ -165,7 +165,7 @@ extension Web3 {
                     return Data(bytes).toHexString().addHexPrefix()
                 } else if let string = rawValue as? String {
                     if let bytes = Data.fromHex(string) {
-                        return string.addHexPrefix()
+                        return bytes.toHexString().addHexPrefix()
                     }
                     return string.data(using: .utf8)?.toHexString().addHexPrefix()
                 }
@@ -179,8 +179,9 @@ extension Web3 {
                 } else if let string = rawValue as? String {
                     if let bytes = Data.fromHex(string) {
                         data = bytes
+                    } else {
+                        data = string.data(using: .utf8)
                     }
-                    data = string.data(using: .utf8)
                 }
 
                 if let data = data,

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -122,7 +122,7 @@ extension Web3 {
             if tail == nil {
                 return code
             }
-            guard let components = URLComponents(string: tail!) else {return code}
+            guard let components = URLComponents(string: tail!.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? tail!) else {return code}
             if components.path == "" {
                 code.isPayRequest = true
             } else {
@@ -133,72 +133,16 @@ extension Web3 {
             var inputs = [ABI.Element.InOut]()
             for comp in queryItems {
                 if let inputType = try? ABITypeParser.parseTypeString(comp.name) {
-                    guard let value = comp.value else {continue}
-                    var nativeValue: AnyObject? = nil
-                    switch inputType {
-                    case .address:
-                        let val = EIP681Code.TargetAddress(value)
-                        switch val {
-                        case .ethereumAddress(let ethereumAddress):
-                            nativeValue = ethereumAddress as AnyObject
-                        //  default:
-                        //      return nil
-                        case .ensAddress(let ens):
-                            do {
-                                let web = web3(provider: InfuraProvider(Networks.fromInt(Int(code.chainID ?? 1)) ?? Networks.Mainnet)!)
-                                let ensModel = ENS(web3: web)
-                                try ensModel?.setENSResolver(withDomain: ens)
-                                let address = try ensModel?.getAddress(forNode: ens)
-                                nativeValue = address as AnyObject
-                            } catch {
-                                return nil
-                            }
-                        }
-                    case .uint(bits: _):
-                        if let val = BigUInt(value, radix: 10) {
-                            nativeValue = val as AnyObject
-                        } else if let val = BigUInt(value.stripHexPrefix(), radix: 16) {
-                            nativeValue = val as AnyObject
-                        }
-                    case .int(bits: _):
-                        if let val = BigInt(value, radix: 10) {
-                            nativeValue = val as AnyObject
-                        } else if let val = BigInt(value.stripHexPrefix(), radix: 16) {
-                            nativeValue = val as AnyObject
-                        }
-                    case .string:
-                        nativeValue = value as AnyObject
-                    case .dynamicBytes:
-                        if let val = Data.fromHex(value) {
-                            nativeValue = val as AnyObject
-                        } else if let val = value.data(using: .utf8) {
-                            nativeValue = val as AnyObject
-                        }
-                    case .bytes(length: _):
-                        if let val = Data.fromHex(value) {
-                            nativeValue = val as AnyObject
-                        } else if let val = value.data(using: .utf8) {
-                            nativeValue = val as AnyObject
-                        }
-                    case .bool:
-                        switch value {
-                        case "true", "True", "TRUE", "1":
-                            nativeValue = true as AnyObject
-                        case "false", "False", "FALSE", "0":
-                            nativeValue = false as AnyObject
-                        default:
-                            nativeValue = true as AnyObject
-                        }
-                    default:
-                        continue
-                    }
-                    if nativeValue != nil {
-                        inputs.append(ABI.Element.InOut(name: String(inputNumber), type: inputType))
-                        code.parameters.append(EIP681Code.EIP681Parameter(type: inputType, value: nativeValue!))
-                        inputNumber = inputNumber + 1
-                    } else {
-                        return nil
-                    }
+                    guard let rawValue = comp.value,
+                          let functionArgument = parseFunctionArgument(inputType,
+                                                                       rawValue.trimmingCharacters(in: .whitespacesAndNewlines),
+                                                                       chainID: code.chainID ?? 0,
+                                                                       inputNumber: inputNumber)
+                    else { continue }
+
+                    inputs.append(functionArgument.argType)
+                    code.parameters.append(functionArgument.parameter)
+                    inputNumber = inputNumber + 1
                 } else {
                     switch comp.name {
                     case "value":
@@ -249,5 +193,196 @@ extension Web3 {
             print(code)
             return code
         }
+
+        private static func parseFunctionArgument(_ inputType: ABI.Element.ParameterType,
+                                                  _ rawValue: String,
+                                                  chainID: BigUInt,
+                                                  inputNumber: Int) -> FunctionArgument? {
+            var parsedValue: AnyObject? = nil
+            switch inputType {
+            case .address:
+                let val = EIP681Code.TargetAddress(rawValue)
+                switch val {
+                case .ethereumAddress(let ethereumAddress):
+                    parsedValue = ethereumAddress as AnyObject
+                case .ensAddress(let ens):
+                    do {
+                        let web = web3(provider: InfuraProvider(Networks.fromInt(Int(chainID)) ?? Networks.Mainnet)!)
+                        let ensModel = ENS(web3: web)
+                        try ensModel?.setENSResolver(withDomain: ens)
+                        let address = try ensModel?.getAddress(forNode: ens)
+                        parsedValue = address as AnyObject
+                    } catch {
+                        return nil
+                    }
+                }
+            case .uint(bits: _):
+                if let val = BigUInt(rawValue, radix: 10) {
+                    parsedValue = val as AnyObject
+                } else if let val = BigUInt(rawValue.stripHexPrefix(), radix: 16) {
+                    parsedValue = val as AnyObject
+                }
+            case .int(bits: _):
+                if let val = BigInt(rawValue, radix: 10) {
+                    parsedValue = val as AnyObject
+                } else if let val = BigInt(rawValue.stripHexPrefix(), radix: 16) {
+                    parsedValue = val as AnyObject
+                }
+            case .string:
+                parsedValue = rawValue as AnyObject
+            case .dynamicBytes:
+                if let val = Data.fromHex(rawValue) {
+                    parsedValue = val as AnyObject
+                } else if let val = rawValue.data(using: .utf8) {
+                    parsedValue = val as AnyObject
+                }
+            case .bytes(length: _):
+                if let val = Data.fromHex(rawValue) {
+                    parsedValue = val as AnyObject
+                } else if let val = rawValue.data(using: .utf8) {
+                    parsedValue = val as AnyObject
+                }
+            case .bool:
+                switch rawValue {
+                case "true", "True", "TRUE", "1":
+                    parsedValue = true as AnyObject
+                case "false", "False", "FALSE", "0":
+                    parsedValue = false as AnyObject
+                default:
+                    parsedValue = true as AnyObject
+                }
+            case let .array(type, length):
+                var rawValues: [String] = []
+                if case .array = type {
+                    guard let internalArrays = splitArrayOfArrays(rawValue),
+                          (length == 0 || UInt64(internalArrays.count) == length) else { return nil }
+                    rawValues = internalArrays
+                } else if case let .tuple(internalTypes) = type {
+                    // TODO: implement!
+                } else if case .string = type {
+                    guard let strings = splitArrayOfStrings(rawValue),
+                          (length == 0 || UInt64(strings.count) == length) else { return nil }
+                    rawValues = strings
+                } else {
+                    let rawValue = String(rawValue.dropFirst().dropLast())
+                    rawValues = rawValue.split(separator: ",").map { String($0) }
+                }
+
+                parsedValue = rawValues.compactMap {
+                    parseFunctionArgument(type,
+                                          String($0),
+                                          chainID: chainID,
+                                          inputNumber: inputNumber)?
+                        .parameter
+                        .value
+                } as AnyObject
+
+                guard (parsedValue as? [AnyObject])?.count == rawValues.count &&
+                        (length == 0 || UInt64(rawValues.count) == length) else { return nil }
+            case let .tuple(types):
+                // TODO: implement!
+                return nil
+            default: return nil
+            }
+
+            guard let parsedValue = parsedValue else { return nil }
+            return FunctionArgument(ABI.Element.InOut(name: String(inputNumber), type: inputType),
+                                    EIP681Code.EIP681Parameter(type: inputType, value: parsedValue))
+        }
+
+        // MARK: - Parsing functions for complex data structures
+
+        /// Attempts to split given ``rawValue`` into `[String]` where each element of that array
+        /// represent a valid, stringified, array in of itself.
+        /// With an input like `"[[],[],[]]"` the output is expected to be `["[]","[]","[]"]`.
+        /// - Parameter rawValue: supposedly an array of arrays in a form `[[...],[...],...]`
+        /// - Returns: separated stringified arrays, or `nil` if separation failed.
+        private static func splitArrayOfArrays(_ rawValue: String) -> [String]? {
+            /// Dropping first and last square brackets.
+            /// That modifies the upper bound value of the first match of `squareBracketRegex`.
+            let rawValue = String(rawValue.dropFirst().dropLast())
+
+            let squareBracketRegex = try! NSRegularExpression(pattern: "(\\[*)")
+            let match = squareBracketRegex.firstMatch(in: rawValue, range: rawValue.fullNSRange)
+
+            guard let bracketsCount = match?.range.upperBound,
+                  bracketsCount > 0 else {
+                return nil
+            }
+
+            let splitRegex = try! NSRegularExpression(pattern: "(\\]){\(bracketsCount)},(\\[){\(bracketsCount)}")
+            var indices: [Int] = splitRegex.matches(in: rawValue, range: rawValue.fullNSRange)
+                .map { $0.range.lowerBound + bracketsCount }
+            if !indices.isEmpty {
+                indices.append(rawValue.count)
+                var prevIndex = 0
+                var result = [String]()
+                for index in indices {
+                    result.append(rawValue[prevIndex..<index])
+                    prevIndex = index + 1
+                }
+                return result
+            }
+            return [rawValue]
+        }
+
+        /// Attempts to split a string that represents an array of strings.
+        /// Example:
+        ///
+        ///      // input
+        ///      "[\"1\",\"abcd,efgh\",\"-=-=-\"]"
+        ///      // output
+        ///      ["1","abcd,efgh","-=-=-"]
+        ///
+        ///      // input
+        ///      "[1,abcd,efgh,-=-=-]"
+        ///      // output
+        ///      ["1","abcd","efgh","-=-=-"]
+        ///
+        /// - Parameter rawValue: stringified array of strings.
+        /// - Returns: an array of separated individual elements, or `nil` if separation failed.
+        private static func splitArrayOfStrings(_ rawValue: String) -> [String]? {
+            /// Dropping first and last square brackets to exclude them from the first and the last separated element.
+            let rawValue = String(rawValue.dropFirst().dropLast())
+
+            let elementsBoundary = try! NSRegularExpression(pattern: "\",\"")
+            var indices = Array(elementsBoundary
+                .matches(in: rawValue, range: rawValue.fullNSRange)
+                .map { result in
+                    result.range.lowerBound + 1
+                })
+
+            if !indices.isEmpty {
+                indices.append(rawValue.count)
+                var prevIndex = 0
+                var rawValues = [String]()
+                for index in indices {
+                    var argument = rawValue[prevIndex..<index]
+                    if let index = argument.firstIndex(of: "\""),
+                       argument.distance(from: argument.startIndex, to: index) == 0 {
+                        argument = String(argument.dropFirst())
+                    }
+                    if let index = argument.lastIndex(of: "\""),
+                       argument.distance(from: argument.endIndex, to: index) == -1 {
+                        argument = String(argument.dropLast())
+                    }
+                    rawValues.append(argument)
+                    prevIndex = index + 1
+                }
+                return rawValues
+            }
+            return rawValue.split(separator: ",").map { String($0) }
+        }
+    }
+}
+
+fileprivate class FunctionArgument {
+    let argType: ABI.Element.InOut
+    let parameter: Web3.EIP681Code.EIP681Parameter
+
+    init(_ argType: ABI.Element.InOut,
+         _ parameter: Web3.EIP681Code.EIP681Parameter) {
+        self.argType = argType
+        self.parameter = parameter
     }
 }

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -63,15 +63,172 @@ extension Web3 {
         }
 
         public func makeEIP681Link() -> String? {
+            let address: String
             switch targetAddress {
             case .ethereumAddress(let ethereumAddress):
-                guard let chainID = chainID,
-                      let functionName = functionName,
-                      let keys = parameters.first?.value,
-                      let values = parameters.last?.value else { return nil }
-                return "ethereum:\(ethereumAddress.address)@\(chainID)/\(functionName)?bytes32[]=\(keys)&bytes[]=\(values)"
-            case .ensAddress:
+                address = ethereumAddress.address
+            case let .ensAddress(ensAdress):
+                address = ensAdress
+            }
+            var link = "ethereum:\(address)\(chainID != nil ? "@\(chainID!.description)" : "")"
+            if let functionName = functionName, !functionName.isEmpty {
+                link = "\(link)/\(functionName)"
+            }
+            if !parameters.isEmpty {
+                let queryParameters: [String] = parameters.compactMap { eip681Parameter in
+                    guard let queryValue = Web3
+                        .EIP681CodeEncoder
+                        .encodeFunctionArgument(eip681Parameter.type, eip681Parameter.value)
+                    else {
+                        return nil
+                    }
+                    return "\(eip681Parameter.type.abiRepresentation)=\(queryValue)"
+                }
+
+                if queryParameters.count == parameters.count {
+                    link = "\(link)?\(queryParameters.joined(separator: "&"))"
+                }
+            }
+            return link
+        }
+    }
+
+    public struct EIP681CodeEncoder {
+        public static func encodeFunctionArgument(_ inputType: ABI.Element.ParameterType,
+                                                   _ rawValue: AnyObject) -> String? {
+            switch inputType {
+            case .address:
+                if let ethAddress = rawValue as? EthereumAddress {
+                    return ethAddress.address
+                }
+                if let bytes = rawValue as? Data,
+                   let ethAddress = EthereumAddress(bytes) {
+                    return ethAddress.address
+                }
+                if let string = rawValue as? String {
+                    if let ethAddress = EthereumAddress(string) {
+                        return ethAddress.address
+                    }
+                    if let url = URL(string: string) {
+                        return string
+                    }
+                }
                 return nil
+            case .uint(bits: _):
+                let value: BigUInt?
+                if let bigInt = rawValue as? BigInt {
+                    value = BigUInt(bigInt)
+                } else if let bigUInt = rawValue as? BigUInt {
+                    value = bigUInt
+                } else if let bytes = rawValue as? Data {
+                    value = BigUInt(bytes)
+                } else if let string = rawValue as? String {
+                    value = BigUInt(string, radix: 10) ?? BigUInt(string.stripHexPrefix(), radix: 16)
+                } else if let number = rawValue as? Int {
+                    value = BigUInt(exactly: number)
+                } else if let number = rawValue as? Double {
+                    value = BigUInt(exactly: number)
+                } else {
+                    value = nil
+                }
+                return value?.description
+            case .int(bits: _):
+                let value: BigInt?
+                if let bigInt = rawValue as? BigInt {
+                    value = bigInt
+                } else if let bigUInt = rawValue as? BigUInt {
+                    value = BigInt(bigUInt)
+                } else if let bytes = rawValue as? Data {
+                    value = BigInt(bytes)
+                } else if let string = rawValue as? String {
+                    value = BigInt(string, radix: 10) ?? BigInt(string.stripHexPrefix(), radix: 16)
+                } else if let number = rawValue as? Int {
+                    value = BigInt(exactly: number)
+                } else if let number = rawValue as? Double {
+                    value = BigInt(exactly: number)
+                } else {
+                    value = nil
+                }
+                return value?.description
+            case .string:
+                if let bytes = rawValue as? Data,
+                   let string = String(data: bytes, encoding: .utf8) {
+                    return string
+                } else if let string = rawValue as? String {
+                    return string
+                }
+                return nil
+            case .dynamicBytes:
+                if let bytes = rawValue as? Data {
+                    return bytes.toHexString().addHexPrefix()
+                } else if let bytes = rawValue as? [UInt8] {
+                    return Data(bytes).toHexString().addHexPrefix()
+                } else if let string = rawValue as? String {
+                    if let bytes = Data.fromHex(string) {
+                        return string.addHexPrefix()
+                    }
+                    return string.data(using: .utf8)?.toHexString().addHexPrefix()
+                }
+                return nil
+            case let .bytes(length):
+                var data: Data? = nil
+                if let bytes = rawValue as? Data {
+                    data = bytes
+                } else if let bytes = rawValue as? [UInt8] {
+                    data = Data(bytes)
+                } else if let string = rawValue as? String {
+                    if let bytes = Data.fromHex(string) {
+                        data = bytes
+                    }
+                    data = string.data(using: .utf8)
+                }
+
+                if let data = data,
+                   data.count == length {
+                    return data.toHexString().addHexPrefix()
+                }
+                return nil
+            case .bool:
+                if let bool = rawValue as? Bool {
+                    return bool ? "true" : "false"
+                }
+                if let number = rawValue as? Int,
+                   let int = BigInt(exactly: number) {
+                    return int == 0 ? "false" : "true"
+                }
+                if let number = rawValue as? Double,
+                   let int = BigInt(exactly: number) {
+                    return int == 0 ? "false" : "true"
+                }
+                if let string = rawValue as? String {
+                    switch string.lowercased() {
+                    case "true", "yes", "1":
+                        return "true"
+                    default:
+                        return "false"
+                    }
+                }
+                if let bytes = rawValue as? Data {
+                    return bytes.count == 0 || bytes.count == 1 && bytes.first == 0 ? "false" : "true"
+                }
+                return nil
+            case let .array(type, length):
+                if let array = rawValue as? [AnyObject] {
+                    let mappedArray = array.compactMap { object in
+                        encodeFunctionArgument(type, object)
+                    }
+
+                    if length != 0 && UInt64(mappedArray.count) == length {
+                        return "[\(mappedArray.joined(separator: ","))]"
+                    } else if length == 0 && mappedArray.count == array.count {
+                        return "[\(mappedArray.joined(separator: ","))]"
+                    }
+                }
+                return nil
+            case let .tuple(types):
+                // TODO: implement!
+                return nil
+            default: return nil
             }
         }
     }

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -62,7 +62,7 @@ extension Web3 {
             self.targetAddress = targetAddress
         }
 
-        public func makeEIP681Link() -> String? {
+        public func makeEIP681Link(urlEncode: Bool = false) -> String? {
             let address: String
             switch targetAddress {
             case .ethereumAddress(let ethereumAddress):
@@ -89,7 +89,7 @@ extension Web3 {
                     link = "\(link)?\(queryParameters.joined(separator: "&"))"
                 }
             }
-            return link
+            return urlEncode ? link.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) : link
         }
     }
 

--- a/Tests/web3swiftTests/localTests/EIP681Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP681Tests.swift
@@ -304,6 +304,12 @@ class EIP681Tests: LocalTestCase {
                                  Web3.EIP681Code.EIP681Parameter(type: .string,
                                                                  value: "this is EIP681 query parameter string" as AnyObject)]
 
-        XCTAssertEqual(eip681Link.makeEIP681Link(), "ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc/setData?bytes32[]=[0x1234789565875498655487123478956587549865548712347895658754980000,0x1234789565875498655487123478956587549865548712347895658754986554]&bytes[]=[0x12345607,0x8965abcdef]&uint256=98986565&int256=155445566&address=0x9aBbDB06A61cC686BD635484439549D45c2449cc&bytes5=0x9abbdb06a6&bytes3=0x9abbdb&bytes=0x11009abbdb87879898656545&string=this is EIP681 query parameter string")
+        let unencodedResult =  "ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc/setData?bytes32[]=[0x1234789565875498655487123478956587549865548712347895658754980000,0x1234789565875498655487123478956587549865548712347895658754986554]&bytes[]=[0x12345607,0x8965abcdef]&uint256=98986565&int256=155445566&address=0x9aBbDB06A61cC686BD635484439549D45c2449cc&bytes5=0x9abbdb06a6&bytes3=0x9abbdb&bytes=0x11009abbdb87879898656545&string=this is EIP681 query parameter string"
+
+        XCTAssertEqual(eip681Link.makeEIP681Link(), unencodedResult)
+        let encodedOutputLink = eip681Link.makeEIP681Link(urlEncode: true)
+        XCTAssertEqual(encodedOutputLink, unencodedResult.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        XCTAssertNotNil(encodedOutputLink)
+        XCTAssertNotNil(URL(string: encodedOutputLink ?? ""))
     }
 }

--- a/Tests/web3swiftTests/localTests/EIP681Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP681Tests.swift
@@ -5,28 +5,277 @@
 //
 
 import XCTest
+import BigInt
+
 @testable import web3swift
 
 class EIP681Tests: LocalTestCase {
 
-    // Custom payment
-    // ethereum:0xfb6916095ca1df60bb79Ce92ce3ea74c37c5d359?value=2.014e18
+    func testParsing() throws {
+        let testAddress = "0x5ffc014343cd971b7eb70732021e26c35b744cc4"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)?value=2.014e18")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address.lowercased(), testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
 
-    // ERC20 transfer
-    // ethereum:0x8932404A197D84Ec3Ea55971AADE11cdA1dddff1/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1
-
-    func testEIP681Parsing() throws {
-        let parsed = Web3.EIP681CodeParser.parse("ethereum:0x5ffc014343cd971b7eb70732021e26c35b744cc4?value=2.014e18")
-        XCTAssert(parsed != nil)
+        XCTAssertEqual(eip681Code.amount, BigUInt(2014000000000000000))
     }
 
-    func testEIP681Parsing2() throws {
-        let parsed = Web3.EIP681CodeParser.parse("ethereum:0x8932404A197D84Ec3Ea55971AADE11cdA1dddff1/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1")
-        XCTAssert(parsed != nil)
+    func testParsingWithEncoding() throws {
+        let testAddress = "0x5ffc014343cd971b7eb70732021e26c35b744cc4"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)?value=2.014e18".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address.lowercased(), testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.amount, BigUInt(2014000000000000000))
     }
 
-    func testEIP681ENSParsing() throws {
-        let parsed = Web3.EIP681CodeParser.parse("ethereum:somename.eth/transfer?address=somename.eth&uint256=1")
-        XCTAssert(parsed != nil)
+    func testParsing2() throws {
+        let testAddress = "0x8932404A197D84Ec3Ea55971AADE11cdA1dddff1"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "transfer")
+        XCTAssertEqual(eip681Code.parameters[0].type, .address)
+        XCTAssertEqual(eip681Code.parameters[1].type, .uint(bits: 256))
+        XCTAssertEqual(eip681Code.parameters[0].value as? EthereumAddress,
+                       EthereumAddress("0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4"))
+        XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
+    }
+
+    func testParsing2WithEncoding() throws {
+        let testAddress = "0x8932404A197D84Ec3Ea55971AADE11cdA1dddff1"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1"
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "transfer")
+        XCTAssertEqual(eip681Code.parameters[0].type, .address)
+        XCTAssertEqual(eip681Code.parameters[1].type, .uint(bits: 256))
+        XCTAssertEqual(eip681Code.parameters[0].value as? EthereumAddress,
+                       EthereumAddress("0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4"))
+        XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
+    }
+
+    func testENSParsing() throws {
+        let testAddress = "somename.eth"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=somename.eth&uint256=1")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(_):
+            fatalError("Returned target address cannot be EthereumAddress. It must be ENS address.")
+        case .ensAddress(let address):
+            XCTAssertEqual(address, testAddress)
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "transfer")
+        XCTAssertEqual(eip681Code.parameters[0].type, .address)
+        /// `eip681Code.parameters[0].value` is not checked as it's fetched from remote and is unknown.
+        /// `eip681Code.parameters[0].value` must contain some `EthereumAddress`
+        // DO NOT UNCOMMENT, unless you know the exact returned value beforehand.
+        // XCTAssertEqual(eip681Code.parameters[0].value as? String, EthereumAddress(...))
+        XCTAssertEqual(eip681Code.parameters[1].type, .uint(bits: 256))
+        XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
+    }
+
+    func testENSParsingWithEncoding() throws {
+        let testAddress = "somename.eth"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=somename.eth&uint256=1".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(_):
+            fatalError("Returned target address cannot be EthereumAddress. It must be ENS address.")
+        case .ensAddress(let address):
+            XCTAssertEqual(address, testAddress)
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "transfer")
+        XCTAssertEqual(eip681Code.parameters[0].type, .address)
+        /// `eip681Code.parameters[0].value` is not checked as it's fetched from remote and is unknown.
+        /// `eip681Code.parameters[0].value` must contain some `EthereumAddress`
+        // DO NOT UNCOMMENT, unless you know the exact returned value beforehand.
+        // XCTAssertEqual(eip681Code.parameters[0].value as? String, EthereumAddress(...))
+        XCTAssertEqual(eip681Code.parameters[1].type, .uint(bits: 256))
+        XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
+    }
+
+    func testParsingOfArrayOfBytesAsParameter() throws {
+        let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
+        let chainID = BigUInt(2828)
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/setData?bytes32[]=[0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428,0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3,0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004]&bytes[]=[0x0000000000000000000000000000000000000000000000000000000000000038,0x0000000000000000000000000000000000000000000000000000000000000004,0x005e9F5BB83481d5627aA8c48527C174579bC428]")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "setData")
+        XCTAssertEqual(eip681Code.function!.signature, "setData(bytes32[],bytes[])")
+        XCTAssertEqual(eip681Code.chainID, chainID)
+        XCTAssertEqual(eip681Code.parameters[0].type, .array(type: .bytes(length: 32), length: 0))
+
+        var data = eip681Code.parameters[0].value as? [Data]
+        XCTAssertEqual(data?[0], Data.fromHex("0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428")!)
+        XCTAssertEqual(data?[1], Data.fromHex("0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3")!)
+        XCTAssertEqual(data?[2], Data.fromHex("0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004")!)
+
+        XCTAssertEqual(eip681Code.parameters[1].type, .array(type: .dynamicBytes, length: 0))
+        data = eip681Code.parameters[1].value as? [Data]
+        XCTAssertEqual(data?[0], Data.fromHex("0x0000000000000000000000000000000000000000000000000000000000000038")!)
+        XCTAssertEqual(data?[1], Data.fromHex("0x0000000000000000000000000000000000000000000000000000000000000004")!)
+        XCTAssertEqual(data?[2], Data.fromHex("0x005e9F5BB83481d5627aA8c48527C174579bC428")!)
+    }
+
+    func testParsingOfArrayOfBytesAsParameterWithEncoding() throws {
+        let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
+        let chainID = BigUInt(2828)
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/setData?bytes32[]=[0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428,0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3,0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004]&bytes[]=[0x0000000000000000000000000000000000000000000000000000000000000038,0x0000000000000000000000000000000000000000000000000000000000000004,0x005e9F5BB83481d5627aA8c48527C174579bC428]".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "setData")
+        XCTAssertEqual(eip681Code.function!.signature, "setData(bytes32[],bytes[])")
+        XCTAssertEqual(eip681Code.chainID, chainID)
+
+        XCTAssertEqual(eip681Code.parameters[0].type, .array(type: .bytes(length: 32), length: 0))
+        var data = eip681Code.parameters[0].value as? [Data]
+        XCTAssertEqual(data?[0], Data.fromHex("0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428")!)
+        XCTAssertEqual(data?[1], Data.fromHex("0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3")!)
+        XCTAssertEqual(data?[2], Data.fromHex("0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004")!)
+
+        XCTAssertEqual(eip681Code.parameters[1].type, .array(type: .dynamicBytes, length: 0))
+        data = eip681Code.parameters[1].value as? [Data]
+        XCTAssertEqual(data?[0], Data.fromHex("0x0000000000000000000000000000000000000000000000000000000000000038")!)
+        XCTAssertEqual(data?[1], Data.fromHex("0x0000000000000000000000000000000000000000000000000000000000000004")!)
+        XCTAssertEqual(data?[2], Data.fromHex("0x005e9F5BB83481d5627aA8c48527C174579bC428")!)
+    }
+
+    func testParsingOfArrayOfIntAsParameter() throws {
+        let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
+        let chainID = BigUInt(2828)
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/functionName123?int256[]=[1,2,5000,3,4,10000]")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "functionName123")
+        XCTAssertEqual(eip681Code.function!.signature, "functionName123(int256[])")
+        XCTAssertEqual(eip681Code.chainID, chainID)
+
+        XCTAssertEqual(eip681Code.parameters[0].type, .array(type: .int(bits: 256), length: 0))
+        let data = eip681Code.parameters[0].value as? [BigInt]
+        XCTAssertEqual(data, Array<BigInt>(arrayLiteral: 1, 2, 5000, 3, 4, 10000))
+    }
+
+    func testParsingOfArrayOfIntOfFixedLengthAsParameter() throws {
+        let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
+        let chainID = BigUInt(2828)
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/functionName123?int256[3]=[1,2,5000]")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "functionName123")
+        XCTAssertEqual(eip681Code.function!.signature, "functionName123(int256[3])")
+        XCTAssertEqual(eip681Code.chainID, chainID)
+
+        XCTAssertEqual(eip681Code.parameters[0].type, .array(type: .int(bits: 256), length: 3))
+        let data = eip681Code.parameters[0].value as? [BigInt]
+        XCTAssertEqual(data, Array<BigInt>(arrayLiteral: 1, 2, 5000))
+    }
+
+    func testParsingQueryParameterFixedLengthArray() throws {
+        /// Declared `int256[3]` with 2 values instead of expected 3.
+        var eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?int256[3]=[1,2]")
+        XCTAssert(eip681Code != nil)
+        XCTAssert(eip681Code?.parameters.count == 0)
+        /// Declared `int256[3]` with 4 values instead of expected 3.
+        eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?int256[3]=[1,2,2,3]")
+        XCTAssert(eip681Code != nil)
+        XCTAssert(eip681Code?.parameters.count == 0)
+    }
+
+    func testParsingQueryParameterStringsArray() throws {
+        var eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[]=[\"123\",\"2,5000\",\"wwweer2-=!\"]")
+        XCTAssert(eip681Code != nil)
+        guard eip681Code != nil else { return }
+
+        XCTAssertEqual(eip681Code!.parameters[0].type, .array(type: .string, length: 0))
+        var data = eip681Code!.parameters[0].value as? [String]
+        XCTAssertEqual(data, ["123","2,5000","wwweer2-=!"])
+
+        eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[]=[123,2,5000,wwweer2-=!]")
+        XCTAssert(eip681Code != nil)
+        guard eip681Code != nil else { return }
+
+        XCTAssertEqual(eip681Code!.parameters[0].type, .array(type: .string, length: 0))
+        data = eip681Code!.parameters[0].value as? [String]
+        XCTAssertEqual(data, ["123","2","5000","wwweer2-=!"])
+    }
+
+    func testParsingQueryParameterArrayOfStringsArrays() throws {
+        var eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[][]=[[\"123\",\"2,5000\",\"wwweer2-=!\"],[\"test1\",\"demo\"]]")
+        XCTAssert(eip681Code != nil)
+        guard eip681Code != nil else { return }
+
+        XCTAssertEqual(eip681Code!.parameters[0].type, .array(type: .array(type: .string, length: 0), length: 0))
+        var data = eip681Code!.parameters[0].value as? [[String]]
+        XCTAssertEqual(data?[0], ["123","2,5000","wwweer2-=!"])
+        XCTAssertEqual(data?[1], ["test1","demo"])
+
+        eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[][]=[[123,2,5000,wwweer2-=!],[test1,demo]]")
+        XCTAssert(eip681Code != nil)
+        guard eip681Code != nil else { return }
+
+        XCTAssertEqual(eip681Code!.parameters[0].type, .array(type: .array(type: .string, length: 0), length: 0))
+        data = eip681Code!.parameters[0].value as? [[String]]
+        XCTAssertEqual(data?[0], ["123","2","5000","wwweer2-=!"])
+        XCTAssertEqual(data?[1], ["test1","demo"])
     }
 }

--- a/Tests/web3swiftTests/localTests/EIP681Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP681Tests.swift
@@ -278,4 +278,32 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(data?[0], ["123","2","5000","wwweer2-=!"])
         XCTAssertEqual(data?[1], ["test1","demo"])
     }
+
+    func testMakeEIP681Link() throws {
+        var eip681Link = Web3.EIP681Code(Web3.EIP681Code.TargetAddress.ethereumAddress(EthereumAddress("0x9aBbDB06A61cC686BD635484439549D45c2449cc")!))
+
+        eip681Link.functionName = "setData"
+        eip681Link.parameters = [Web3.EIP681Code.EIP681Parameter(type: .array(type: .bytes(length: 32), length: 0),
+                                                                 value: [Data.fromHex("0x1234789565875498655487123478956587549865548712347895658754980000")!,
+                                                                         Data.fromHex("0x1234789565875498655487123478956587549865548712347895658754986554")!] as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .array(type: .dynamicBytes, length: 0),
+                                                                 value: [Data.fromHex("0x12345607")!,
+                                                                         Data.fromHex("0x8965abcdef")!] as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .uint(bits: 256),
+                                                                 value: 98986565 as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .int(bits: 256),
+                                                                 value: 155445566 as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .address,
+                                                                 value: EthereumAddress("0x9aBbDB06A61cC686BD635484439549D45c2449cc")! as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .bytes(length: 5),
+                                                                 value: "0x9aBbDB06A6" as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .bytes(length: 3),
+                                                                 value: Data.fromHex("0x9aBbDB")! as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .dynamicBytes,
+                                                                 value: Data.fromHex("0x11009aBbDB87879898656545")! as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .string,
+                                                                 value: "this is EIP681 query parameter string" as AnyObject)]
+
+        XCTAssertEqual(eip681Link.makeEIP681Link(), "ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc/setData?bytes32[]=[0x1234789565875498655487123478956587549865548712347895658754980000,0x1234789565875498655487123478956587549865548712347895658754986554]&bytes[]=[0x12345607,0x8965abcdef]&uint256=98986565&int256=155445566&address=0x9aBbDB06A61cC686BD635484439549D45c2449cc&bytes5=0x9abbdb06a6&bytes3=0x9abbdb&bytes=0x11009abbdb87879898656545&string=this is EIP681 query parameter string")
+    }
 }


### PR DESCRIPTION
# The problem

Having EIP681 link like this one:
```
ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[]=[123,2,5000,wwweer2-=!]
```

during parsing will result in loss of query parameters and function name and the result would be the following link:
```
ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828
```

# What is introduced in this PR?

1) EIP681 parsing of arrays in query parameters. Tuples are not yet handled.
2) Encoding of `EIP681Code.parameters` parameters usable in URL.
3) Added `func makeEIP681Link(urlEncoded: Bool) -> String?` to create EIP681 link from `EIP681Code`. `EIP681Code` structure is used to create an EIP681 URL in a `String` representation with an option to URL encode the EIP681 link before it's returned so it's an actually valid URL.
4) Fixed old test cases for EIP681 and added new ones.