### PR TITLE
fix: detailed response of parsing EIP4361

### DIFF
--- a/Sources/web3swift/Utils/EIP/EIP4361.swift
+++ b/Sources/web3swift/Utils/EIP/EIP4361.swift
@@ -82,17 +82,17 @@ public final class EIP4361 {
     public static func validate(_ message: String) -> EIP4361ValidationResponse {
         let siweConstantMessageRegex = try! NSRegularExpression(pattern: "^\(domain)")
         guard siweConstantMessageRegex.firstMatch(in: message, range: message.fullNSRange) != nil else {
-            return EIP4361ValidationResponse(isEIP4361: false, eip4361: nil, parsedFields: [:])
+            return EIP4361ValidationResponse(isEIP4361: false, eip4361: nil, capturedFields: [:])
         }
 
         let eip4361Regex = try! NSRegularExpression(pattern: eip4361OptionalPattern)
-        var parsedFields: [EIP4361Field: String] = [:]
+        var capturedFields: [EIP4361Field: String] = [:]
         for (key, value) in eip4361Regex.captureGroups(string: message) {
-            parsedFields[.init(rawValue: key)!] = value
+            capturedFields[.init(rawValue: key)!] = value
         }
         return EIP4361ValidationResponse(isEIP4361: true,
                                   eip4361: EIP4361(message),
-                                  parsedFields: parsedFields)
+                                         capturedFields: capturedFields)
     }
 
     /// `domain` is the RFC 3986 authority that is requesting the signing.
@@ -198,7 +198,7 @@ public final class EIP4361 {
 public struct EIP4361ValidationResponse {
     public let isEIP4361: Bool
     public let eip4361: EIP4361?
-    public let parsedFields: [EIP4361.EIP4361Field: String]
+    public let capturedFields: [EIP4361.EIP4361Field: String]
 
     public var isValid: Bool {
         eip4361 != nil

--- a/Sources/web3swift/Utils/EIP/EIP4361.swift
+++ b/Sources/web3swift/Utils/EIP/EIP4361.swift
@@ -13,7 +13,11 @@ fileprivate let datetimePattern = "[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[
 fileprivate let uriPattern = "(([^:?#\\s]+):)?(([^?#\\s]*))?([^?#\\s]*)(\\?([^#\\s]*))?(#(.*))?"
 
 /// Sign-In with Ethereum protocol and parser implementation.
-/// [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361)
+/// EIP-4361:
+///    - https://eips.ethereum.org/EIPS/eip-4361
+///    - https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4361.md
+///
+/// Thanks to spruceid for SIWE implementation that was rewritten here in Swift: https://github.com/spruceid/siwe/blob/main/packages/siwe-parser/lib/regex.ts
 ///
 /// ## How to use?
 ///

--- a/Sources/web3swift/Utils/EIP/EIP4361.swift
+++ b/Sources/web3swift/Utils/EIP/EIP4361.swift
@@ -10,27 +10,85 @@ import BigInt
 public typealias SIWE = EIP4361
 
 fileprivate let datetimePattern = "[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(.[0-9]+)?(([Zz])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))"
-fileprivate let uriPattern = "(([^:?#]+):)?(([^?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+fileprivate let uriPattern = "(([^:?#\\s]+):)?(([^?#\\s]*))?([^?#\\s]*)(\\?([^#\\s]*))?(#(.*))?"
 
 /// Sign-In with Ethereum protocol and parser implementation.
 /// [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361)
+///
+/// ## How to use?
+///
+/// The best approach on how to get an instance of `EIP4361` is by calling the function ``EIP4361/validate(_:)``
+/// which in return gives you all the information you need for checking which SIWE attributes are missing or invalid,
+/// and parsed `EIP4361` object itself if the raw message indeed was a SIWE message.
+///
+/// ```swift
+/// let validationResponse = EIP4361.validate(rawStringMessage)
+/// guard validationResponse.isEIP4361 else { return }
+///
+/// if validationResponse.isValid {
+///    // Safe to force unwrap the `eip4361`
+///    validationResponse.eip4361!
+///    ...
+/// } else {
+///     // e.g. present user with an error message ...
+///     // or
+///     // use `validationResponse.parsedFields` to check which fields are missing or invalid
+///     let isAddressValid = EthereumAddress(validationResponse[.address] ?? "") != nil
+///     ...
+/// }
+/// ```
 public final class EIP4361 {
 
-    private static let domain = "(?<domain>([^?#]*)) wants you to sign in with your Ethereum account:"
-    private static let address = "\\n(?<address>0x[a-zA-Z0-9]{40})\\n\\n"
-    private static let statementParagraph = "((?<statement>[^\\n]+)\\n)?"
-    private static let uri = "\\nURI: (?<uri>(\(uriPattern))?)"
-    private static let version = "\\nVersion: (?<version>1)"
-    private static let chainId = "\\nChain ID: (?<chainId>[0-9a-fA-F]+)"
-    private static let nonce = "\\nNonce: (?<nonce>[a-zA-Z0-9]{8,})"
-    private static let issuedAt = "\\nIssued At: (?<issuedAt>(\(datetimePattern)))"
-    private static let expirationTime = "(\\nExpiration Time: (?<expirationTime>(\(datetimePattern))))?"
-    private static let notBefore = "(\\nNot Before: (?<notBefore>(\(datetimePattern))))?"
-    private static let requestId = "(\\nRequest ID: (?<requestId>[-._~!$&'()*+,;=:@%a-zA-Z0-9]*))?"
-    private static let resourcesParagraph = "(\\nResources:(?<resources>(\\n- (\(uriPattern))?)+))?"
+    public enum EIP4361Field: String {
+        case domain = "domain"
+        case address = "address"
+        case statement = "statement"
+        case uri = "uri"
+        case version = "version"
+        case chainId = "chainId"
+        case nonce = "nonce"
+        case issuedAt = "issuedAt"
+        case expirationTime = "expirationTime"
+        case notBefore = "notBefore"
+        case requestId = "requestId"
+        case resources = "resources"
+    }
+
+    private static let domain = "(?<\(EIP4361Field.domain.rawValue)>([^?#]*)) wants you to sign in with your Ethereum account:"
+    private static let address = "\\n(?<\(EIP4361Field.address.rawValue)>0x[a-zA-Z0-9]{40})\\n\\n"
+    private static let statementParagraph = "((?<\(EIP4361Field.statement.rawValue)>[^\\n]+)\\n)?"
+    private static let uri = "\\nURI: (?<\(EIP4361Field.uri.rawValue)>(\(uriPattern))?)"
+    private static let version = "\\nVersion: (?<\(EIP4361Field.version.rawValue)>[0-9]+)"
+    private static let chainId = "\\nChain ID: (?<\(EIP4361Field.chainId.rawValue)>[0-9a-fA-F]+)"
+    private static let nonce = "\\nNonce: (?<\(EIP4361Field.nonce.rawValue)>[a-zA-Z0-9]{8,})"
+    private static let issuedAt = "\\nIssued At: (?<\(EIP4361Field.issuedAt.rawValue)>(\(datetimePattern)))"
+    private static let expirationTime = "(\\nExpiration Time: (?<\(EIP4361Field.expirationTime.rawValue)>(\(datetimePattern))))?"
+    private static let notBefore = "(\\nNot Before: (?<\(EIP4361Field.notBefore.rawValue)>(\(datetimePattern))))?"
+    private static let requestId = "(\\nRequest ID: (?<\(EIP4361Field.requestId.rawValue)>[-._~!$&'()*+,;=:@%a-zA-Z0-9]*))?"
+    private static let resourcesParagraph = "(\\nResources:(?<\(EIP4361Field.resources.rawValue)>(\\n- (\(uriPattern))?)+))?"
 
     private static var eip4361Pattern: String {
         "^\(domain)\(address)\(statementParagraph)\(uri)\(version)\(chainId)\(nonce)\(issuedAt)\(expirationTime)\(notBefore)\(requestId)\(resourcesParagraph)$"
+    }
+
+    private static var eip4361OptionalPattern: String {
+        "^\(domain)(\(address))?\(statementParagraph)(\(uri))?(\(version))?(\(chainId))?(\(nonce))?(\(issuedAt))?\(expirationTime)\(notBefore)\(requestId)\(resourcesParagraph)$"
+    }
+
+    public static func validate(_ message: String) -> EIP4361ValidationResponse {
+        let siweConstantMessageRegex = try! NSRegularExpression(pattern: "^\(domain)")
+        guard siweConstantMessageRegex.firstMatch(in: message, range: message.fullNSRange) != nil else {
+            return EIP4361ValidationResponse(isEIP4361: false, eip4361: nil, parsedFields: [:])
+        }
+
+        let eip4361Regex = try! NSRegularExpression(pattern: eip4361OptionalPattern)
+        var parsedFields: [EIP4361Field: String] = [:]
+        for (key, value) in eip4361Regex.captureGroups(string: message) {
+            parsedFields[.init(rawValue: key)!] = value
+        }
+        return EIP4361ValidationResponse(isEIP4361: true,
+                                  eip4361: EIP4361(message),
+                                  parsedFields: parsedFields)
     }
 
     /// `domain` is the RFC 3986 authority that is requesting the signing.
@@ -71,6 +129,7 @@ public final class EIP4361 {
               let uri = URL(string: rawUri),
               let rawVersion = groups["version"],
               let version = BigUInt(rawVersion, radix: 10) ?? BigUInt(rawVersion, radix: 16),
+              version == 1,
               let rawChainId = groups["chainId"],
               let chainId = BigUInt(rawChainId, radix: 10) ?? BigUInt(rawChainId, radix: 16),
               let nonce = groups["nonce"],
@@ -129,3 +188,15 @@ public final class EIP4361 {
     }
 }
 
+/// A structure that holds the information about Sign In With Ethereum message and allows you to check
+/// if the raw message is indeed a SIWE message, if it's a valid SIWE, which fields are present in the message
+/// and if it's a valid message holds a reference to fully parsed ``EIP4361`` object.
+public struct EIP4361ValidationResponse {
+    public let isEIP4361: Bool
+    public let eip4361: EIP4361?
+    public let parsedFields: [EIP4361.EIP4361Field: String]
+
+    public var isValid: Bool {
+        eip4361 != nil
+    }
+}

--- a/Tests/web3swiftTests/localTests/EIP4361Test.swift
+++ b/Tests/web3swiftTests/localTests/EIP4361Test.swift
@@ -36,4 +36,134 @@ class EIP4361Test: XCTestCase {
                                                URL(string: "https://example.com/my-web2-claim.json")!])
         XCTAssertEqual(siweMessage.description, rawSiweMessage)
     }
+
+    func test_EIP4361StaticValidationFunc() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+
+        guard validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message.")
+            return
+        }
+
+        let siweMessage = validationResponse.eip4361!
+
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        XCTAssertEqual(siweMessage.domain, "service.invalid")
+        XCTAssertEqual(siweMessage.address, EthereumAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")!)
+        XCTAssertEqual(siweMessage.statement, "I accept the ServiceOrg Terms of Service: https://service.invalid/tos")
+        XCTAssertEqual(siweMessage.uri, URL(string: "https://service.invalid/login")!)
+        XCTAssertEqual(siweMessage.version, 1)
+        XCTAssertEqual(siweMessage.chainId, 1)
+        XCTAssertEqual(siweMessage.nonce, "32891756")
+        XCTAssertEqual(siweMessage.issuedAt, dateFormatter.date(from: "2021-09-30T16:25:24.345Z")!)
+        XCTAssertEqual(siweMessage.expirationTime, dateFormatter.date(from: "2021-09-29T15:25:24.234Z")!)
+        XCTAssertEqual(siweMessage.notBefore, dateFormatter.date(from: "2021-10-28T14:25:24.123Z")!)
+        XCTAssertEqual(siweMessage.requestId, "random-request-id_STRING!@$%%&")
+        XCTAssertEqual(siweMessage.resources, [URL(string: "ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/")!,
+                                               URL(string: "https://example.com/my-web2-claim.json")!])
+        XCTAssertEqual(siweMessage.description, rawSiweMessage)
+    }
+
+    func test_validEIP4361_noOptionalFields() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isValid else {
+            XCTFail("Failed to parse valid SIWE message.")
+            return
+        }
+
+        XCTAssertNotNil(validationResponse.eip4361)
+        XCTAssertNil(validationResponse.parsedFields[.expirationTime])
+        XCTAssertNil(validationResponse.parsedFields[.notBefore])
+        XCTAssertNil(validationResponse.parsedFields[.requestId])
+        XCTAssertNil(validationResponse.parsedFields[.resources])
+    }
+
+    func test_invalidEIP4361_missingAddress() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:I accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.address])
+    }
+
+    func test_invalidEIP4361_missingUri() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nVersion: 1\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.uri])
+    }
+
+    func test_invalidEIP4361_missingVersion() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.version])
+    }
+
+    func test_invalidEIP4361_missingChainId() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.chainId])
+    }
+
+    func test_invalidEIP4361_missingNonce() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.nonce])
+    }
+
+    func test_invalidEIP4361_missingIssuedAt() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nNonce: 32891756\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.issuedAt])
+    }
+
+    func test_invalidEIP4361_wrongVersionNumber() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 123\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertEqual(validationResponse.parsedFields[.version], "123")
+    }
 }

--- a/Tests/web3swiftTests/localTests/EIP4361Test.swift
+++ b/Tests/web3swiftTests/localTests/EIP4361Test.swift
@@ -77,10 +77,10 @@ class EIP4361Test: XCTestCase {
         }
 
         XCTAssertNotNil(validationResponse.eip4361)
-        XCTAssertNil(validationResponse.parsedFields[.expirationTime])
-        XCTAssertNil(validationResponse.parsedFields[.notBefore])
-        XCTAssertNil(validationResponse.parsedFields[.requestId])
-        XCTAssertNil(validationResponse.parsedFields[.resources])
+        XCTAssertNil(validationResponse.capturedFields[.expirationTime])
+        XCTAssertNil(validationResponse.capturedFields[.notBefore])
+        XCTAssertNil(validationResponse.capturedFields[.requestId])
+        XCTAssertNil(validationResponse.capturedFields[.resources])
     }
 
     func test_invalidEIP4361_missingAddress() {
@@ -92,7 +92,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.address])
+        XCTAssertNil(validationResponse.capturedFields[.address])
     }
 
     func test_invalidEIP4361_missingUri() {
@@ -104,7 +104,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.uri])
+        XCTAssertNil(validationResponse.capturedFields[.uri])
     }
 
     func test_invalidEIP4361_missingVersion() {
@@ -116,7 +116,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.version])
+        XCTAssertNil(validationResponse.capturedFields[.version])
     }
 
     func test_invalidEIP4361_missingChainId() {
@@ -128,7 +128,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.chainId])
+        XCTAssertNil(validationResponse.capturedFields[.chainId])
     }
 
     func test_invalidEIP4361_missingNonce() {
@@ -140,7 +140,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.nonce])
+        XCTAssertNil(validationResponse.capturedFields[.nonce])
     }
 
     func test_invalidEIP4361_missingIssuedAt() {
@@ -152,7 +152,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.issuedAt])
+        XCTAssertNil(validationResponse.capturedFields[.issuedAt])
     }
 
     func test_invalidEIP4361_wrongVersionNumber() {
@@ -164,6 +164,6 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertEqual(validationResponse.parsedFields[.version], "123")
+        XCTAssertEqual(validationResponse.capturedFields[.version], "123")
     }
 }


### PR DESCRIPTION
Enhanced EIP4361 feature: `EIP4361.validate(...)` returns validation object that holds:
- `isEIP4361` flag that tells if the message given for validation represents EIP4361;
- `isValid` - tells if EIP4361 message is meeting all requirements;
- optional `EIP4361` that is safe to force unwrap if `isValid` equals `true`;
- a dictionary of all successfully extracted (not parsed) fields with raw values for each field. Values are accessed by a new enum `EIP4361Field`.

This combination allows getting the reason for failed message parsing, e.g. if `capturedFields` does not contain value for `EIP4361Field.address` it's safe to assume that message does not contain the address field which is required.