### PR TITLE
fix: updated Web3Error to inherit from LocalizedError

### DIFF
--- a/Sources/web3swift/Web3/Web3.swift
+++ b/Sources/web3swift/Web3/Web3.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public enum Web3Error: Error {
+public enum Web3Error: LocalizedError {
     case transactionSerializationError
     case connectionError
     case dataError
@@ -18,7 +18,7 @@ public enum Web3Error: Error {
     case generalError(err: Error)
     case unknownError
 
-    public var errorDescription: String {
+    public var errorDescription: String? {
         switch self {
 
         case .transactionSerializationError:


### PR DESCRIPTION
Web3Error now inherits from LocalizedError to support `localizedError` attribute.